### PR TITLE
Fix compatibility and crash with Battle.net client v1.29.0.12511

### DIFF
--- a/bnetlauncher/Clients/BnetClient.cs
+++ b/bnetlauncher/Clients/BnetClient.cs
@@ -159,41 +159,12 @@ namespace bnetlauncher.Clients
         /// <returns>number of battle.net helper processes required.</returns>
         protected int GetHelperProcessCount()
         {
-            // Ideally I'd use a JSON library and properly parse the battle.net config file, but that
-            // would add a library dependency to the project so instead we'll do the hackish alternative
-            // of just regexing the config file.
-            try
-            {
-                // Location of the battle.net client configuration file in JSON
-                var bnet_config_file = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                    "Battle.net", "Battle.net.config");
-
-                // Read the config file into a string
-                var bnet_config = File.ReadAllText(bnet_config_file);
-
-                // Use a Regular expression to search for the HardwareAcceleration option and see if it's ON or OFF
-                // if it's ON then the client will have at least 2 Battle.net Helper running.
-                var match = Regex.Match(bnet_config, "\"HardwareAcceleration\":.*\"(true|false)\"");
-
-                if (match.Success)
-                {
-                    if (match.Groups[1].Value.Equals("true", StringComparison.OrdinalIgnoreCase))
-                    {
-                        return 2;
-                    }
-                    else
-                    {
-                        // Hardware acceleration is off, so no GPU battle.net helper
-                        return 1;
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"Error reading '{Id}' config file.", ex);
-            }
-
-            return 2;
+            // Since WoW shadowlands launch the non beta Battle.net Client requires the UI to fully
+            // load before accepting commands, and disabling GPU acelaration no longers reduces the
+            // thread count by one, so this value is now a constant 3, function remains in case this
+            // changes again in the future.
+            // NOTE: See code before tag 2.12 for previous function if needed.
+            return 3;
         }
 
         /// <summary>

--- a/bnetlauncher/Properties/AssemblyInfo.cs
+++ b/bnetlauncher/Properties/AssemblyInfo.cs
@@ -50,6 +50,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.11.*")]
-//[assembly: AssemblyFileVersion("2.11.*")]
+[assembly: AssemblyVersion("2.12.*")]
+//[assembly: AssemblyFileVersion("2.12.*")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/bnetlauncher/Utils/WinApi.cs
+++ b/bnetlauncher/Utils/WinApi.cs
@@ -104,7 +104,7 @@ namespace bnetlauncher.Utils
             }
 
             Logger.Information("Sending enter key to window");
-            NativeMethods.SendMessage(handle, NativeMethods.WM_KEYDOWN, ToPtr(NativeMethods.VK_RETURN), IntPtr.Zero);
+            NativeMethods.SendMessage(handle, NativeMethods.WM_KEYDOWN, (IntPtr)NativeMethods.VK_RETURN, IntPtr.Zero);
         }
 
         public static IntPtr ToPtr(int val)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 Version History
 ---------------
+2.12
+* Fix for Battle.net client needing to have UI loaded before responding to game launch commands
+
+2.11
+* Added Call of Duty: Modern Warfare 2 Campaign Remastered
+* Added Call of Duty: Back Ops Cold War
+* Experimental Epic game support
+
 2.10
 * Added Call of Duty: Modern Warfare 2 Campaign Remastered support
 * Added experimental support for some games using epic client.


### PR DESCRIPTION
This version of battle.net client requires one additional helper to be able to launch games, additionally disabling GPU acceleration no longer affects the number of helper threads.

Also when launching games with Battlenet2 games the SendMessage was causing the battle.net client to crash, this bug was introduced in PR #48 in a misguided attempt to make the code more "correct".

This addresses issue #49