### PR TITLE
Add support for World of Warcraft Classic Era (for hardcore and *true* vanilla classic realms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with minimal/no interaction with the battle.net client while still being automat
 |d2r            | Diablo 2: Resurrected                                 |
 |d3             | Diablo 3                                              |
 |d3ptr          | Diablo 3 Public Test Realm                            |
-|d4beta         | Diablo IV Beta                                        |
+|d4             | Diablo IV Beta                                        |
 |di             | Diablo Immortal                                       |
 |hs             | Heartstone                                            |
 |hots           | Heroes of the Storm                                   |
@@ -177,4 +177,4 @@ Explaining what each part does:
 * github jacobmix for crash bandicoot 4 addition
 * github KyleStilkey for Diablo Immortal support
 * github d3rt0xx for MW2 & WZ2.0 support
-* github Sectimus for Diablo IV Beta support
+* github Sectimus for Diablo IV support

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with minimal/no interaction with the battle.net client while still being automat
 |d2r            | Diablo 2: Resurrected                                 |
 |d3             | Diablo 3                                              |
 |d3ptr          | Diablo 3 Public Test Realm                            |
-|d4             | Diablo IV Beta                                        |
+|d4             | Diablo IV                                             |
 |di             | Diablo Immortal                                       |
 |hs             | Heartstone                                            |
 |hots           | Heroes of the Storm                                   |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ with minimal/no interaction with the battle.net client while still being automat
 |w3             | Warcraft 3: Reforged                                  |
 |wow            | World of Warcraft                                     |
 |wowclassic     | World of Warcraft Classic                             |
+|wowclassicera  | World of Warcraft Classic Era                         |
 |wowptr         | World of Warcraft Public Test Realm                   |
 
 the result should look something like the example or screenshot bellow:
@@ -178,3 +179,4 @@ Explaining what each part does:
 * github KyleStilkey for Diablo Immortal support
 * github d3rt0xx for MW2 & WZ2.0 support
 * github Sectimus for Diablo IV support
+* github Sectimus for WoW Classic Era support

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ with minimal/no interaction with the battle.net client while still being automat
 |d2r            | Diablo 2: Resurrected                                 |
 |d3             | Diablo 3                                              |
 |d3ptr          | Diablo 3 Public Test Realm                            |
+|d4beta         | Diablo IV Beta                                        |
 |di             | Diablo Immortal                                       |
 |hs             | Heartstone                                            |
 |hots           | Heroes of the Storm                                   |

--- a/bnetlauncher/Properties/AssemblyInfo.cs
+++ b/bnetlauncher/Properties/AssemblyInfo.cs
@@ -50,6 +50,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.21.*")]
-//[assembly: AssemblyFileVersion("2.21.*")]
+[assembly: AssemblyVersion("2.22.*")]
+//[assembly: AssemblyFileVersion("2.22.*")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/bnetlauncher/Properties/AssemblyInfo.cs
+++ b/bnetlauncher/Properties/AssemblyInfo.cs
@@ -50,6 +50,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.20.*")]
-//[assembly: AssemblyFileVersion("2.20.*")]
+[assembly: AssemblyVersion("2.21.*")]
+//[assembly: AssemblyFileVersion("2.21.*")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/bnetlauncher/Properties/AssemblyInfo.cs
+++ b/bnetlauncher/Properties/AssemblyInfo.cs
@@ -50,6 +50,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.18.*")]
-//[assembly: AssemblyFileVersion("2.18.*")]
+[assembly: AssemblyVersion("2.19.*")]
+//[assembly: AssemblyFileVersion("2.19.*")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/bnetlauncher/Properties/AssemblyInfo.cs
+++ b/bnetlauncher/Properties/AssemblyInfo.cs
@@ -50,6 +50,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.22.*")]
-//[assembly: AssemblyFileVersion("2.22.*")]
+[assembly: AssemblyVersion("2.23.*")]
+//[assembly: AssemblyFileVersion("2.23.*")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/bnetlauncher/Properties/AssemblyInfo.cs
+++ b/bnetlauncher/Properties/AssemblyInfo.cs
@@ -50,6 +50,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.19.*")]
-//[assembly: AssemblyFileVersion("2.19.*")]
+[assembly: AssemblyVersion("2.20.*")]
+//[assembly: AssemblyFileVersion("2.20.*")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/bnetlauncher/Resources/gamesdb.ini
+++ b/bnetlauncher/Resources/gamesdb.ini
@@ -107,6 +107,12 @@ client=battlenet2
 cmd=d3t
 exe=Diablo III%.exe
 
+[d4beta]
+name=Diablo 4 Beta
+client=battlenet2
+cmd=fenrisb
+exe=Diablo IV.exe
+
 [di]
 name=Diablo Immortal
 client=battlenet

--- a/bnetlauncher/Resources/gamesdb.ini
+++ b/bnetlauncher/Resources/gamesdb.ini
@@ -109,7 +109,7 @@ exe=Diablo III%.exe
 
 [d4]
 name=Diablo 4
-client=battlenet2
+client=battlenet
 cmd=Fen
 exe=Diablo IV.exe
 

--- a/bnetlauncher/Resources/gamesdb.ini
+++ b/bnetlauncher/Resources/gamesdb.ini
@@ -137,6 +137,12 @@ client=battlenet2
 cmd=wow_classic
 exe=WowClassic.exe
 
+[wowclassicera]
+name=World of Warcraft Classic Era
+client=battlenet2
+cmd=wow_classic_era
+exe=WowClassic.exe
+
 [wowptr]
 name=World of Warcraft Public Test Realm
 client=battlenet2

--- a/bnetlauncher/Resources/gamesdb.ini
+++ b/bnetlauncher/Resources/gamesdb.ini
@@ -107,10 +107,10 @@ client=battlenet2
 cmd=d3t
 exe=Diablo III%.exe
 
-[d4beta]
-name=Diablo 4 Beta
+[d4]
+name=Diablo 4
 client=battlenet2
-cmd=fenrisb
+cmd=fenris
 exe=Diablo IV.exe
 
 [di]

--- a/bnetlauncher/Resources/gamesdb.ini
+++ b/bnetlauncher/Resources/gamesdb.ini
@@ -110,7 +110,7 @@ exe=Diablo III%.exe
 [d4]
 name=Diablo 4
 client=battlenet2
-cmd=fenris
+cmd=Fen
 exe=Diablo IV.exe
 
 [di]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 Version History
 ---------------
 
+2.19
++ Added Diablo IV Beta support courtesy of Sectimus
+
 2.18
 + Added Call of Duty: Modern Warfare 2 + Warzone 2 support courtesy of d3rt0xx
 + Added Epic Borderlands 3 support

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 Version History
 ---------------
 2.21
-+ Changed Diablo IV launch argument based on licence change
++ Changed Diablo IV launch argument based on license change
 
 2.20
 + Added Diablo IV support and removing Diablo IV Beta support courtesy of Sectimus

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 Version History
 ---------------
 
+2.20
++ Added Diablo IV support and removing Diablo IV Beta support courtesy of Sectimus
+
 2.19
 + Added Diablo IV Beta support courtesy of Sectimus
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 Version History
 ---------------
+2.23
++ Added World of Warcraft Classic Era support courtesy of Sectimus 
+
 2.21
 + Changed Diablo IV launch argument based on license change
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 Version History
 ---------------
+2.21
++ Changed Diablo IV launch argument based on licence change
 
 2.20
 + Added Diablo IV support and removing Diablo IV Beta support courtesy of Sectimus


### PR DESCRIPTION
tag v2.23
There is no distinction between classic era and classic world of warcraft in bnetlauncher so using the parameter of "wowclassic" will always launch the (current WotLK) expansion edition. With the launch of Hardcore, myself and others are looking to launch the classic era version of the game more often and would like to be able to launch separately.

See linked issue:
https://github.com/dafzor/bnetlauncher/issues/70 